### PR TITLE
User Management Pages hidden from Nav Bar

### DIFF
--- a/resources/views/layouts/sidenav.blade.php
+++ b/resources/views/layouts/sidenav.blade.php
@@ -58,6 +58,8 @@
           <span class="sidebar-text">Profile</span>
         </a>
       </li>
+      @auth
+        @if(auth()->user()->role_id === 1)
       <li class="nav-item">
         <span class="nav-link collapsed d-flex justify-content-between align-items-center" data-bs-toggle="collapse"
           data-bs-target="#submenu-laravel" aria-expanded="true">
@@ -116,6 +118,8 @@
           </ul>
         </div>
       </li>
+        @endif
+      @endauth
       <li class="nav-item {{ Request::segment(1) == 'transactions' ? 'active' : '' }}">
         <a href="/transactions" class="nav-link">
           <span class="sidebar-icon"><svg class="icon icon-xs me-2" fill="currentColor" viewBox="0 0 20 20"


### PR DESCRIPTION
## Pull Request Summary:
This PR hides User Management pages from the navigation bar for a cleaner interface.

### Changes Made:
- Removed User Management links from the navigation menu.

### Reasoning:
To simplify the navigation and focus on essential user functionalities, User Management links are removed from the main menu.

## Checklist:
- [x] Confirmed the absence of User Management links.
- [x] Ensured no adverse effects on other navigation elements.

Feedback and review are appreciated. Thank you!
